### PR TITLE
Add Resource column for greater context of Archival Object search results

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ ArchivesSpace plugins directory.  For example:
      cd /path/to/your/archivesspace/plugins
      git clone https://github.com/hudmol/component_levels.git component_levels
 
+
+## Database Migration
+
+This plugin requires your Archival Objects to be re-indexed.  This is triggered by running the plugin's
+database migration via the command:
+
+     cd /path/to/archivesspace
+     scripts/setup-database.sh

--- a/indexer/component_levels_indexer.rb
+++ b/indexer/component_levels_indexer.rb
@@ -1,0 +1,13 @@
+class CommonIndexer
+  add_attribute_to_resolve('resource')
+
+  add_indexer_initialize_hook do |indexer|
+    indexer.add_document_prepare_hook {|doc, record|
+      if record['record']['jsonmodel_type'] == 'archival_object'
+        resource = record['record']['resource']['_resolved']
+        doc['resource_identifier_u_sstr'] = (0..3).map{|i| resource["id_#{i}"]}.compact.join(".")
+        doc['resource_title_u_sstr'] = resource['title']
+      end
+    }
+  end
+end

--- a/migrations/001_reindex_all_archival_objects.rb
+++ b/migrations/001_reindex_all_archival_objects.rb
@@ -1,0 +1,9 @@
+require 'db/migrations/utils'
+
+Sequel.migration do
+
+  up do
+    self[:archival_object].update(:system_mtime => Time.now)
+  end
+
+end


### PR DESCRIPTION
When indexing an Archival Object also store the record's resource identifier and title.  Then display these resource fields in a new column in the search result listing
