### PR TITLE
[Delivers 99080532] Ensure the Level column is displayed when a filter is applied

### DIFF
--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -65,7 +65,8 @@ Rails.application.config.after_initialize do
       (ASUtils.wrap(@search_data.types).empty? ||
         @search_data.types.include?("resource") || @search_data.types.include?("archival_object")) &&
       (!@search_data.filtered_terms? ||
-        @search_data[:criteria]["filter_term[]"].select{|filter| filter =~ /primary_type/ }.any?{|filter| filter =~ /archival_object/ || filter =~ /resource/ })
+        @search_data[:criteria]["filter_term[]"].none?{|filter| filter =~ /primary_type/ } ||
+        @search_data[:criteria]["filter_term[]"].any?{|filter| filter =~ /primary_type/ && (filter =~ /archival_object/ || filter =~ /resource/) })
     end
   end
 


### PR DESCRIPTION
… to the general search by fixing the conditional checking the filters for primary_type - if there are no primary_type filter_terms then need to assume that archival objects or resources may still be in the result set.
